### PR TITLE
Update config.w32 with sentinel sources

### DIFF
--- a/config.w32
+++ b/config.w32
@@ -5,7 +5,7 @@ ARG_ENABLE("redis-session", "whether to enable sessions", "yes");
 ARG_ENABLE("redis-igbinary", "whether to enable igbinary serializer support", "no");
 
 if (PHP_REDIS != "no") {
-	var sources = "redis.c redis_commands.c library.c redis_session.c redis_array.c redis_array_impl.c redis_cluster.c cluster_library.c";
+	var sources = "redis.c redis_commands.c library.c redis_session.c redis_array.c redis_array_impl.c redis_cluster.c cluster_library.c redis_sentinel.c sentinel_library.c";
 	if (PHP_REDIS_SESSION != "no") {
 		ADD_EXTENSION_DEP("redis", "session");
 		ADD_FLAG("CFLAGS_REDIS", ' /D PHP_SESSION=1 ');


### PR DESCRIPTION
The sentinel sources were added to config.m4 in https://github.com/phpredis/phpredis/commit/c94e28f1ebabdfceb722ad78eff75ce4fc57f5a3#diff-788d457a20b110cc38e571dec9ddc68c

They should be added to config.w32 as well.